### PR TITLE
openconnect command stays empty if script is executed as root

### DIFF
--- a/fortigate_vpn_login/cli.py
+++ b/fortigate_vpn_login/cli.py
@@ -183,7 +183,7 @@ def main() -> int:
     else:
         if not os.getuid() == 0:
             command_line.append("sudo")
-            command_line = command_line + [str(openconnect_path)] + openconnect_arguments
+        command_line = command_line + [str(openconnect_path)] + openconnect_arguments
 
     env = os.environ.copy()
     env['LC_ALL'] = 'C'


### PR DESCRIPTION
variable command_line is not filled, if script is run as root